### PR TITLE
Fix error where two JSON.parse were being done

### DIFF
--- a/bitbucket/request.js
+++ b/bitbucket/request.js
@@ -93,9 +93,8 @@ module.exports = function Request(_options) {
           return;
         }
 
-        const response = options.use_xhr ? _response : result.decodeResponse(_response);
         if (callback) {
-          callback(null, response);
+          callback(null, _response);
         }
       });
     },


### PR DESCRIPTION
At the response end the function decodeResponse is always called for 200 OK requests (making a JSON.parse).

After that the doSend callback is executed, calling the decodeResponse function again, causing an exception, since the parse object isn't a JSON string anymore (it is a concrete object at this point).

I didn't see a problem removing the call to decodeResponse of the doSend callback since it'll always be called at the response end.